### PR TITLE
feat: restrict linting to relevant source files for performance

### DIFF
--- a/nano-eslint.novaextension/CHANGELOG.md
+++ b/nano-eslint.novaextension/CHANGELOG.md
@@ -9,3 +9,8 @@
 ## Version 0.3
 
 - add eslint fix option (@StirStudios)
+
+## Version 0.4
+
+- fix double save when fix option is enabled (@StirStudios)
+- avoid excessive warnings (@StirStudios)

--- a/nano-eslint.novaextension/Scripts/main.js
+++ b/nano-eslint.novaextension/Scripts/main.js
@@ -82,7 +82,7 @@ async function lint(configpath, filepath) {
 async function maybeLint(editor) {
 	try {
 		const filepath = editor.document.path
-		if (!filepath) return []
+		if (!filepath || !filepath.match(/\.(js|ts|vue|mjs|cjs|mts|cts)$/)) return
 
 		const eslintConfigFileNames = (
 			nova.config.get("org.nano-eslint.config_names", "array") ?? []

--- a/nano-eslint.novaextension/extension.json
+++ b/nano-eslint.novaextension/extension.json
@@ -3,7 +3,7 @@
 	"name": "nESLint",
 	"organization": "AJ Caldwell",
 	"description": "Barely abstracted ESLint",
-	"version": "0.3",
+	"version": "0.4",
 	"categories": ["issues"],
 	"repository": "https://github.com/tomatrow/nano-eslint",
 	"bugs": "https://github.com/tomatrow/nano-eslint/issues",


### PR DESCRIPTION
This update ensures ESLint only runs on source files with extensions: .js, .ts, .vue, .mjs, .cjs, .mts, .cts. Previously, non-source files like .env, .css, and .eslintignore were being scanned, causing unnecessary warnings and slower performance. This improves both speed and developer experience by narrowing the scope of linting.